### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 🤖 A Model Context Protocol (MCP) server that allows AI tools to log their activities to daily worklog files with detailed tracking of tool names, AI models, and timestamps.
 
+<a href="https://glama.ai/mcp/servers/@nocoo/mcp-work-history">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@nocoo/mcp-work-history/badge" alt="Work History Server MCP server" />
+</a>
+
 ## ✨ Features
 
 - 🕐 **Precise timestamps** - Logs activities with HH:MM format


### PR DESCRIPTION
This PR adds a badge for the [MCP Work History Server](https://glama.ai/mcp/servers/@nocoo/mcp-work-history) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@nocoo/mcp-work-history">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@nocoo/mcp-work-history/badge" alt="Work History Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a visual badge with a clickable link to the MCP Work History server page on glama.ai in the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->